### PR TITLE
add missing quicklook framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -101,6 +101,7 @@
         <framework src="Storekit.framework" weak="true"/>
         <framework src="SystemConfiguration.framework" weak="true"/>
         <framework src="UIKit.framework" weak="true"/>
+        <framework src="QuickLook.framework" weak="true" />
     </platform>
 
 </plugin>


### PR DESCRIPTION
Without this framework I get the build error:

```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_QLPreviewController", referenced from:
      objc-class-ref in libApptentiveConnect.a(ATAttachmentController.o)
      objc-class-ref in libApptentiveConnect.a(ATMessageCenterViewController.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
