### PR TITLE
IOSOSX-595: Update with distribution version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,11 +71,7 @@
             <string>$IOS_API_KEY</string>
         </config-file>
 
-        <config-file target="*/Resources/ApptentiveResources.bundle/Info.plist" parent="ATInfoDistributionKey">
-            <string>Cordova</string>
-        </config-file>
-
-        <config-file target="*/Resources/ApptentiveResources.bundle/Info.plist" parent="ATInfoDistributionVersionKey">
+        <config-file target="*-Info.plist" parent="ApptentivePluginVersion">
             <string>3.2.0</string>
         </config-file>
 

--- a/src/ios/ApptentiveBridge.m
+++ b/src/ios/ApptentiveBridge.m
@@ -136,6 +136,7 @@
     // Access Info.plist for ApptentiveAPIKey
     NSDictionary *infoPlist = [[NSBundle mainBundle] infoDictionary];
     NSString *apiKey = [infoPlist objectForKey:@"ApptentiveAPIKey"];
+    NSString *pluginVersion = [infoPlist objectForKey:@"ApptentivePluginVersion"];
 
     NSLog(@"Initializing Apptentive API Key: %@", apiKey);
 
@@ -144,7 +145,7 @@
         return;
     }
     if (![apiKey isEqualToString:@""]) {
-        [[Apptentive sharedConnection] setAPIKey:apiKey distributionName:@"Cordova" distributionVersion:CDV_VERSION];
+        [[Apptentive sharedConnection] setAPIKey:apiKey distributionName:@"Cordova" distributionVersion:pluginVersion];
         apptentiveInitted = YES;
     }
 }

--- a/src/ios/ApptentiveBridge.m
+++ b/src/ios/ApptentiveBridge.m
@@ -144,7 +144,7 @@
         return;
     }
     if (![apiKey isEqualToString:@""]) {
-        [Apptentive sharedConnection].APIKey = apiKey;
+        [[Apptentive sharedConnection] setAPIKey:apiKey distributionName:@"Cordova" distributionVersion:CDV_VERSION];
         apptentiveInitted = YES;
     }
 }

--- a/src/ios/apptentive_ios_sdk/include/Apptentive.h
+++ b/src/ios/apptentive_ios_sdk/include/Apptentive.h
@@ -102,6 +102,17 @@ Before calling any other methods on the shared `Apptentive` instance, set the AP
 @property (copy, nonatomic, nullable) NSString *APIKey;
 
 /**
+ Sets the API key along with distribution name and distribution version.
+ This is used when the Apptentive SDK is bundled into another SDK for
+ distribution, for example Apache Cordova.
+ 
+ @param APIKey The API key to use for the first connection to the Apptentive API.
+ @param distributionName The name of the distribution that includes the Apptentive SDK. For example "Cordova".
+ @param distributionVersion The version of the distribution that includes the Apptentive SDK.
+ */
+- (void)setAPIKey:(NSString *)APIKey distributionName:(NSString *)distributionName distributionVersion:(NSString *)distributionVersion;
+
+/**
   APIKey property with legacy capitalization.
 
  @deprecated Capitalize `API` in the property/setter name.


### PR DESCRIPTION
Before merging, we should update to the latest iOS release that contains the fix for IOSOSX-595 (along with whatever other stuff we build/fix). This is just to get the bridge working and tested with the new distribution feature. 

Here's what we send to the server: 

``` son
{
    "sdk": {
        "programming_language": "Objective-C",
        "distribution_version": "4.1.1",
        "author_name": "Apptentive, Inc.",
        "platform": "iOS",
        "version": "3.2.1",
        "distribution": "Cordova"
    },
    "device": {
        "uuid": "A61E94FE-A00B-448F-8B29-81C2D067EB5F"
    },
    "app_release": {
        "debug": false,
        "overriding_styles": true,
        "build_number": "0.0.1",
        "version": "0.0.1",
        "app_store_receipt": {
            "has_receipt": false,
            "file_name": "receipt"
        }
    }
}
```
