### PR TITLE
unify plugin id and package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.1.1",
   "description": "Apptentive Plugin For Cordova",
   "cordova": {
-    "id": "com.apptentive.cordova",
+    "id": "apptentive-cordova",
     "platforms": [
       "android",
       "ios"
@@ -35,4 +35,3 @@
     "xcode": ">=0.9.3"
   }
 }
-

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="com.apptentive.cordova" version="5.1.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="apptentive-cordova" version="5.1.1">
 
     <name>Apptentive</name>
     <description>Apptentive Plugin For Cordova</description>


### PR DESCRIPTION
when i remove plugins and platforms folders and run `cordova prepare` it fails to restore the apptentive plugin with the following error.
```
Discovered plugin "com.apptentive.cordova" in config.xml. Adding it to the project
Failed to restore plugin "com.apptentive.cordova" from config.xml. You might need to try adding it again. Error: Failed to fetch plugin com.apptentive.cordova@~5.1.1 via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Error: npm: Command failed with exit code 1 Error output:
npm WARN notice Due to a recent security incident, all user tokens have been invalidated. Please see https://status.npmjs.org/incidents/dn7c1fgrr7ng for more details. To generate a new token, visit https://www.npmjs.com/settings/~/tokens or run "npm login".
npm ERR! code E404
npm ERR! 404 Not Found: com.apptentive.cordova@~5.1.1
```
cordova 8.0.0

here i propose the fix by unifying the naming. 