### PR TITLE
Embed iOS framework with the app binary

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -95,7 +95,7 @@
         <framework src="Storekit.framework" weak="true"/>
         <framework src="SystemConfiguration.framework" weak="true"/>
         <framework src="UIKit.framework" weak="true"/>
-        <framework src="src/ios/Apptentive.xcframework" custom="true"/>
+        <framework src="src/ios/Apptentive.xcframework" embed="true" custom="true"/>
     </platform>
 
 </plugin>


### PR DESCRIPTION
The app would crash at run-time on the device while attempting to load a dynamic framework