### PR TITLE
Add 'registerWithLogs' function to Android and iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -78,6 +78,10 @@
             <string>5.8.3</string>
         </config-file>
 
+        <config-file target="*-Info.plist" parent="ApptentiveLogLevel">
+            <string>info</string>
+        </config-file>
+
         <!-- ApptentiveBridge -->
         <header-file src="src/ios/ApptentiveBridge.h" target-dir="Apptentive"/>
         <source-file src="src/ios/ApptentiveBridge.m" target-dir="Apptentive"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -78,10 +78,6 @@
             <string>5.8.3</string>
         </config-file>
 
-        <config-file target="*-Info.plist" parent="ApptentiveLogLevel">
-            <string>info</string>
-        </config-file>
-
         <!-- ApptentiveBridge -->
         <header-file src="src/ios/ApptentiveBridge.h" target-dir="Apptentive"/>
         <source-file src="src/ios/ApptentiveBridge.m" target-dir="Apptentive"/>

--- a/src/android/ApptentiveBridge.java
+++ b/src/android/ApptentiveBridge.java
@@ -69,6 +69,16 @@ public class ApptentiveBridge extends CordovaPlugin {
                     @Override
                     public void run() {
                         ApptentiveConfiguration configuration = resolveConfiguration(currentActivity.getApplication());
+
+                        // Parse log level, info by default
+                        String newLogLevel;
+                        try {
+                          newLogLevel = args.getString(0);
+                        } catch (JSONException e) {
+                          newLogLevel = "info";
+                        }
+                        configuration.setLogLevel(parseLogLevel(newLogLevel));
+
                         Apptentive.register(currentActivity.getApplication(), configuration);
                         Application.ActivityLifecycleCallbacks callbacks = ApptentiveActivityLifecycleCallbacks.getInstance();
                         if (callbacks != null) {
@@ -290,6 +300,16 @@ public class ApptentiveBridge extends CordovaPlugin {
 
         callbackContext.error("Unhandled action in ApptentiveBridge: " + action);
         return false;
+    }
+
+    private static ApptentiveLog.Level parseLogLevel(String logLevel) {
+      if (logLevel.equals("verbose")) { return ApptentiveLog.Level.VERBOSE; }
+      if (logLevel.equals("debug")) { return ApptentiveLog.Level.DEBUG; }
+      if (logLevel.equals("info")) { return ApptentiveLog.Level.INFO; }
+      if (logLevel.equals("warn")) { return ApptentiveLog.Level.WARN; }
+      if (logLevel.equals("error")) { return ApptentiveLog.Level.ERROR; }
+      if (logLevel.equals("assert")) { return ApptentiveLog.Level.ASSERT; }
+      return ApptentiveLog.Level.UNKNOWN;
     }
 
     private static ApptentiveConfiguration resolveConfiguration(Context context) {

--- a/src/ios/ApptentiveBridge.m
+++ b/src/ios/ApptentiveBridge.m
@@ -20,7 +20,12 @@
 
 	//initialization
 	if ([functionCall isEqualToString:@"deviceReady"]) {
-		[self initAPIKey:callbackId];
+		// Set log level if present, info level by default
+		if ([command arguments].count == 2) {
+      [self initAPIKey:callbackId withLogLevel:[command argumentAtIndex:1]];
+		} else {
+			[self initAPIKey:callbackId withLogLevel:@"info"];
+		}
 		return;
 	}
 	if (!apptentiveInitialized) {
@@ -107,18 +112,17 @@
 }
 
 #pragma mark Initialization and Events
-- (void)initAPIKey:(NSString *)callbackId {
+- (void)initAPIKey:(NSString *)callbackId withLogLevel:(NSString *)logLevel {
 	// Access Info.plist for ApptentiveAPIKey
 	NSDictionary *infoPlist = [[NSBundle mainBundle] infoDictionary];
 	NSString *apptentiveKey = [infoPlist objectForKey:@"ApptentiveKey"];
 	NSString *apptentiveSignature = [infoPlist objectForKey:@"ApptentiveSignature"];
 	NSString *pluginVersion = [infoPlist objectForKey:@"ApptentivePluginVersion"];
-	NSString *loglevel = [infoPlist objectForKey:@"ApptentiveLogLevel"];
 
-	NSLog(@"APPTENTIVE TEST: Log level is: %@", loglevel);
-
-	// FIXME: Do we really want to be logging this?
-	NSLog(@"Initializing Apptentive Apptentive App Key: %@, Apptentive App Signature: %@", apptentiveKey, apptentiveSignature);
+	// Log key and signature with verbose logs
+	if ([logLevel isEqualToString:@"verbose"]) {
+		NSLog(@"Initializing Apptentive Apptentive App Key: %@, Apptentive App Signature: %@", apptentiveKey, apptentiveSignature);
+	}
 
 	if (apptentiveKey.length == 0 || apptentiveSignature.length == 0) {
 		[self sendFailureMessage:@"Insufficient arguments - no API key." callbackId:callbackId];
@@ -135,6 +139,7 @@
 		ApptentiveConfiguration *configuration = [ApptentiveConfiguration configurationWithApptentiveKey:apptentiveKey apptentiveSignature:apptentiveSignature];
 		configuration.distributionName = @"Cordova";
 		configuration.distributionVersion = pluginVersion;
+		configuration.logLevel = [self parseLogLevel:logLevel];
 
 		[Apptentive registerWithConfiguration:configuration];
 	}
@@ -144,6 +149,16 @@
 	if (styleSheetURL != nil) {
 		Apptentive.shared.styleSheet = [[ApptentiveStyleSheet alloc] initWithContentsOfURL:styleSheetURL];
 	}
+}
+
+- (ApptentiveLogLevel)parseLogLevel:(NSString *) logLevel {
+	if ([logLevel isEqualToString:@"verbose"]) { return ApptentiveLogLevelVerbose; }
+	if ([logLevel isEqualToString:@"debug"]) { return ApptentiveLogLevelDebug; }
+	if ([logLevel isEqualToString:@"info"]) { return ApptentiveLogLevelInfo; }
+	if ([logLevel isEqualToString:@"warn"]) { return ApptentiveLogLevelWarn; }
+	if ([logLevel isEqualToString:@"error"]) { return ApptentiveLogLevelError; }
+	if ([logLevel isEqualToString:@"critical"]) { return ApptentiveLogLevelCrit; }
+	return ApptentiveLogLevelUndefined;
 }
 
 - (void)registerForMessageNotifications:(NSArray *)arguments callBackString:(NSString *)callbackId {

--- a/src/ios/ApptentiveBridge.m
+++ b/src/ios/ApptentiveBridge.m
@@ -113,6 +113,9 @@
 	NSString *apptentiveKey = [infoPlist objectForKey:@"ApptentiveKey"];
 	NSString *apptentiveSignature = [infoPlist objectForKey:@"ApptentiveSignature"];
 	NSString *pluginVersion = [infoPlist objectForKey:@"ApptentivePluginVersion"];
+	NSString *loglevel = [infoPlist objectForKey:@"ApptentiveLogLevel"];
+
+	NSLog(@"APPTENTIVE TEST: Log level is: %@", loglevel);
 
 	// FIXME: Do we really want to be logging this?
 	NSLog(@"Initializing Apptentive Apptentive App Key: %@, Apptentive App Signature: %@", apptentiveKey, apptentiveSignature);
@@ -126,7 +129,7 @@
 			NSLog(@"Apptentive key or signature mismatch. The SDK is not initialized.");
 			return;
 		}
-		
+
 		NSLog(@"WARNING: Apptentive instance is already initialized!");
 	} else {
 		ApptentiveConfiguration *configuration = [ApptentiveConfiguration configurationWithApptentiveKey:apptentiveKey apptentiveSignature:apptentiveSignature];

--- a/www/ApptentiveAndroid.js
+++ b/www/ApptentiveAndroid.js
@@ -12,6 +12,11 @@ var Apptentive = {
         cordova.exec(successCallback, errorCallback, "ApptentiveBridge", "deviceReady", []);
     },
 
+    registerWithLogs: function (successCallback, errorCallback, loglevel) {
+        console.log("Apptentive.registerWithLogs()");
+        cordova.exec(successCallback, errorCallback, "ApptentiveBridge", "deviceReady", [loglevel]);
+    },
+
     engage: function (successCallback, errorCallback, eventName, customData) {
         if (customData && typeof customData === 'object') {
             cordova.exec(successCallback, errorCallback, "ApptentiveBridge", "engage", [eventName, customData]);

--- a/www/ApptentiveIos.js
+++ b/www/ApptentiveIos.js
@@ -15,6 +15,12 @@ var Apptentive = {
         cordova.exec(successCallback, errorCallback, "ApptentiveBridge", "execute", ["deviceReady"]);
     },
 
+    registerWithLogs: function (successCallback, errorCallback, loglevel) {
+        console.log("Apptentive.registerWithLogs()");
+        Apptentive.initialized = true;
+        cordova.exec(successCallback, errorCallback, "ApptentiveBridge", "execute", ["deviceReady", loglevel]);
+    },
+
     engage: function (successCallback, errorCallback, eventName, customData) {
         if (customData) {
             cordova.exec(successCallback, errorCallback, "ApptentiveBridge", "execute", ["engage", eventName, customData]);


### PR DESCRIPTION
- Add 'registerWithLogs' function to Android and iOS platforms to clearly and easily set ApptentiveConfiguration log level