### PR TITLE
Fix a build error on iOS, make region case-insensitive

### DIFF
--- a/src/ios/ApptentiveBridge.swift
+++ b/src/ios/ApptentiveBridge.swift
@@ -293,7 +293,7 @@ class ApptentiveBridge: CDVPlugin, Sendable {
             environment = .custom(overrideBaseURL)
         }
 
-        guard let region = Apptentive.Region(rawValue: regionString) else {
+        guard let region = Apptentive.Region(rawValue: regionString.lowercased()) else {
             throw PluginError.unrecognizedRegionCode(regionString)
         }
 

--- a/src/ios/ApptentiveBridge.swift
+++ b/src/ios/ApptentiveBridge.swift
@@ -184,7 +184,7 @@ class ApptentiveBridge: CDVPlugin, Sendable {
 
                         let result = CDVPluginResult(status: CDVCommandStatus.ok, messageAs: count)
                         result.setKeepCallbackAs(true)
-                        self.commandDelegate.send(result, callbackId: callbackID)
+                        self?.commandDelegate.send(result, callbackId: callbackID)
                     }
                 }
             }


### PR DESCRIPTION
I believe the new Xcode version introduced a build error for iOS, which this PR fixes. It also makes the region case-insensitive so that customers can specify `eu` or `EU` (or `Eu` or `eU` even :) )